### PR TITLE
Add optional text around edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 * [x] Add SVG shapes for background colour
 * [x] Switch text input values when switching images/faces
 * [x] Turn off autocomplete restoring values on page
-* [ ] Button to use this face's text across all faces
+* [x] Button to use this face's text across all faces
 
 ## A tool to make custom hexahexaflexagons
 
@@ -37,7 +37,7 @@ There are several steps and it requires a bit of patience and a fair dose of pre
 
 1. Now that you have the two pieces cut out (whether by Cricut or by hand), you can fold each of them in half the long way and glue to hold the halves together. Again, the more precise you are, the better the final results. Make sure the edges line up. You should end up with two strips printed on both sides, a longer one with A/B triangles at the ends, and a shorter one with a/b triangles at the ends. Allow the glue to set.
 
-2. Now we want to join the two strips into one. Glue the **A** triangle to the **a** triangle so the paper forms one long strip of 19 triangles printed on both sides with B/b triangles at the ends. DO NOT GLUE THE B/b TRIANGLES YET! Allow the glue to set
+2. Now we want to join the two strips into one. Glue the **A** triangle to the **a** triangle so the paper forms one long strip of 19 triangles printed on both sides with B/b triangles at the ends. **DO NOT GLUE THE B/b TRIANGLES YET!** Allow the glue to set
 
 3. We want the triangles pre-folded, so starting at one end, fold the first triangle back behind the strip (mountain fold). If you used a Cricut, these lines should already be scored to make this easier. Make a good crease, then unfold it and move to the next triangle, folding on the lines separating the triangles, one by one, until every line has been pre-creased. Again, precision is important.
 
@@ -62,3 +62,5 @@ There are several steps and it requires a bit of patience and a fair dose of pre
 11. There should be one triangle sticking out of the hexagon. If you flip it over, you should see the **B** and **b** triangles adjacent to each other. Fold the **B** over the **b** and glue them in place. Allow the glue to set.
 
 ### Flexing the Hexaflexagon
+
+Coming soon, but in the meantime there is this [WikiHow article](https://www.wikihow.com/Fold-a-Hexaflexagon#Flexing-Your-Hexaflexagon).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Flexagon
 
+## TODO and where I've left off
+
+* [ ] Add CSS for hide text feature
+* [ ] Text hide text feature
+* [ ] Add CSS for hide images feature
+* [ ] Test hide images feature
+* [ ] Get text from inputs to optional fields around hexagon
+* [ ] Position optional fields properly
+* [ ] Add CSS for background colour only on text fields that are used
+
 ## A tool to make custom hexahexaflexagons
 
 A hexahexaflexagon is a paper toy with six edges (the first hexa-) and six sides (the second hexa-). It appears to be a 2-sided hexagon, but by flexing it (that's the flexa- part) you can reveal the remaining sides. This is a tool to put your own images on the six sides.
@@ -13,15 +23,7 @@ There are several steps and it requires a bit of patience and a fair dose of pre
 3. Within the hexagon at the top of the tool drag to pan and use the mouse wheel to zoom the image
 4. Use the radio buttons to change images and repeat until all 6 images are in position
 
-### Cut out the Hexahexaflexagon (Cricut Method)
-
-1. If you have access to a Cricut cutter, use the Save [Coming soon!] button to save the SVG of your work
-2. Import that into Cricut Design Space
-3. In Design Space mark the blue lines for cutting and the grey lines for scoring
-4. Use heavy paper, thin cardstock, or photo paper
-5. If you have a colour printer attached, the Cricut will prompt you to print, then feed the result into the printer. If you do not have an attached printer, you can output a PDF file with alignment marks that can be printed and then fed into the Cricut.
-
-### Cut out the Hexahexaflexagon (cut by hand)
+### Print and cut out the Hexahexaflexagon
 
 1. Use heavy paper, thin cardstock, or photo paper
 2. You can print from the web page without saving the SVG first

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 * [x] Test hide images feature
 * [x] Get text from inputs to optional fields around hexagon
 * [x] Position optional fields properly
-* [ ] Add CSS for background colour only on text fields that are used
-* [ ] Add SVG shapes for background colour
-* [ ] Switch text input values when switching images/faces
+* [x] Add CSS for background colour only on text fields that are used
+* [x] Add SVG shapes for background colour
+* [x] Switch text input values when switching images/faces
+* [x] Turn off autocomplete restoring values on page
+* [ ] Button to use this face's text across all faces
 
 ## A tool to make custom hexahexaflexagons
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 ## TODO and where I've left off
 
-* [ ] Add CSS for hide text feature
-* [ ] Text hide text feature
-* [ ] Add CSS for hide images feature
-* [ ] Test hide images feature
-* [ ] Get text from inputs to optional fields around hexagon
-* [ ] Position optional fields properly
+* [x] Add CSS for hide text feature
+* [x] Text hide text feature
+* [x] Add CSS for hide images feature
+* [x] Test hide images feature
+* [x] Get text from inputs to optional fields around hexagon
+* [x] Position optional fields properly
 * [ ] Add CSS for background colour only on text fields that are used
+* [ ] Add SVG shapes for background colour
+* [ ] Switch text input values when switching images/faces
 
 ## A tool to make custom hexahexaflexagons
 

--- a/hexa.css
+++ b/hexa.css
@@ -44,6 +44,14 @@ svg {
   padding: 2em;
 }
 
+.on_top polygon{
+   fill: transparent;
+}
+
+.on_top.has_text polygon{
+    fill: #FFF;
+}
+
 #options label {
   text-align: right;
 }

--- a/hexa.css
+++ b/hexa.css
@@ -5,6 +5,18 @@ body {
   padding: 0;
 }
 
+body.hide_images .triangle_image{
+  display: none;
+}
+
+body.hide_text text{
+  display: none;
+}
+
+body.hide_text text.never_hide{
+  display: inline;
+}
+
 #intro {
   padding: 2em;
 }

--- a/hexa.css
+++ b/hexa.css
@@ -5,6 +5,10 @@ body {
   padding: 0;
 }
 
+#intro {
+  padding: 2em;
+}
+
 svg {
   margin-bottom: 2em;
 }
@@ -25,6 +29,15 @@ svg {
 #controls form {
   display: flex;
   flex-direction: column;
+  padding: 2em;
+}
+
+#options label {
+  text-align: right;
+}
+
+#options input {
+  width: 70%;
 }
 
 #controls form > * {

--- a/index.html
+++ b/index.html
@@ -12,38 +12,48 @@
     <script src="js/hexa.js" type="module" async defer></script>
   </head>
   <body>
-  <video style="display:none" id="video" width="640" height="480" autoplay></video>
-  <canvas style="display:none" id="canvas" width="640" height="480"></canvas>
+    <video
+      style="display: none"
+      id="video"
+      width="640"
+      height="480"
+      autoplay
+    ></video>
+    <canvas style="display: none" id="canvas" width="640" height="480"></canvas>
+    <section class="noprint" id="intro">
+      <h1>Hexahexaflexagon Tool</h1>
+      <p>
+        Welcome to the hexahexflexagon tool! If you print this (and cut, fold,
+        and glue according to the
+        <a href="https://hackmd.io/eawNw6gyTCibG64dc3SC8w?view">instructions</a
+        >), you will get a kind of paper kaleidoscope, but that's just the
+        beginning! You can add your own custom images and use the controls to
+        position them in the hexagon, and make your very own hexahexaflexagon.
+      </p>
+
+      <p>
+        Simply choose the hex, and drag a picture to it (or use the buttons to
+        pick a new picture or use the camera). You can scale with the mouse
+        wheel and drag to position.
+      </p>
+
+      <p hidden>
+        You can also save the result to have an SVG file suitable for use with
+        Cricut-style cutting machines.
+      </p>
+    </section>
     <section class="noprint" id="controls">
       <div>
-        <h1>Hexahexaflexagon Tool</h1>
-        <p>
-          Welcome to the hexahexflexagon tool! If you print this (and cut, fold,
-          and glue according to the <a href="https://hackmd.io/eawNw6gyTCibG64dc3SC8w?view">instructions</a>), you will get a kind of paper
-          kaleidoscope, but that's just the beginning! You can add your own
-          custom images and use the controls to position them in the hexagon,
-          and make your very own hexahexaflexagon.
-        </p>
-
-        <p>
-          Simply choose the hex, and drag a picture to it (or use the buttons to
-          pick a new picture or use the camera). You can scale with the mouse
-          wheel and drag to position.
-        </p>
-
-        <p hidden>
-          You can also save the result to have an SVG file suitable for use with
-          Cricut-style cutting machines.
-        </p>
+        <svg
+          id="hex"
+          width="350"
+          height="300"
+          viewBox="0 0 350 300"
+          draggable="true"
+        ></svg>
       </div>
-      <svg
-        id="hex"
-        width="350"
-        height="300"
-        viewBox="0 0 350 300"
-        draggable="true"
-      ></svg>
       <form>
+        <h3>Choose (or take photos) 6 images</h3>
         <label
           ><input type="radio" name="image" value="1" checked /> Image
           One</label
@@ -54,13 +64,50 @@
         <label><input type="radio" name="image" value="5" /> Image Five</label>
         <label><input type="radio" name="image" value="6" /> Image Six</label>
         <hr />
-        <label><input type="file" name="filepicker" id="filepicker" /> Load an image</label>
-        <label><button id="take-photo" type="button">Take a Photo</button><br />
+        <label
+          ><input type="file" name="filepicker" id="filepicker" /> Load an
+          image</label
+        >
+        <button id="take-photo" type="button">Take a Photo</button><br />
         <button id="download-file" type="button" hidden>Download File</button>
+      </form>
+      <form id="options">
+        <h3>Optional text around the edges</h3>
+        <label>Top Edge <input type="text" id="text1" /></label>
+        <label>Upper Right <input type="text" id="text2" /></label>
+        <label>Lower Right <input type="text" id="text3" /></label>
+        <label>Bottom Edge <input type="text" id="text4" /></label>
+        <label>Lower Left <input type="text" id="text5" /></label>
+        <label>Upper Left <input type="text" id="text6" /></label>
       </form>
     </section>
     <svg id="strip1" viewBox="-1 -1 1034 300"></svg>
     <svg id="strip2" viewBox="-1 -1 1034 300"></svg>
-    <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">Flexagon</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://dethe.github.io/flexagon/" property="cc:attributionName" rel="cc:attributionURL">Dethe Elza</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.<br />Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="https://github.com/dethe/flexagon" rel="dct:source">https://github.com/dethe/flexagon</a>.
+    <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"
+      ><img
+        alt="Creative Commons License"
+        style="border-width: 0"
+        src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a
+    ><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title"
+      >Flexagon</span
+    >
+    by
+    <a
+      xmlns:cc="http://creativecommons.org/ns#"
+      href="https://dethe.github.io/flexagon/"
+      property="cc:attributionName"
+      rel="cc:attributionURL"
+      >Dethe Elza</a
+    >
+    is licensed under a
+    <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"
+      >Creative Commons Attribution-ShareAlike 4.0 International License</a
+    >.<br />Based on a work at
+    <a
+      xmlns:dct="http://purl.org/dc/terms/"
+      href="https://github.com/dethe/flexagon"
+      rel="dct:source"
+      >https://github.com/dethe/flexagon</a
+    >.
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -73,12 +73,13 @@
       </form>
       <form id="options">
         <h3>Optional text around the edges</h3>
-        <label>Top Edge <input type="text" id="text1" data-idx="a" /></label>
-        <label>Upper Right <input type="text" id="text2" data-idx="b" /></label>
-        <label>Lower Right <input type="text" id="text3" data-idx="c" /></label>
-        <label>Bottom Edge <input type="text" id="text4" data-idx="d" /></label>
-        <label>Lower Left <input type="text" id="text5" data-idx="e" /></label>
-        <label>Upper Left <input type="text" id="text6" data-idx="f" /></label>
+        <label>Top Edge <input type="text" id="text1" data-idx="a" autocomplete="off" /></label>
+        <label>Upper Right <input type="text" id="text2" data-idx="b" autocomplete="off" /></label>
+        <label>Lower Right <input type="text" id="text3" data-idx="c" autocomplete="off" /></label>
+        <label>Bottom Edge <input type="text" id="text4" data-idx="d" autocomplete="off" /></label>
+        <label>Lower Left <input type="text" id="text5" data-idx="e" autocomplete="off" /></label>
+        <label>Upper Left <input type="text" id="text6" data-idx="f" autocomplete="off" /></label>
+        <button id="copy_text" type="button">Copy this text to all sides</button>
         <hr>
         <h3>Advanced Options</h3>
         <label>Hide Images <input type="checkbox" id="hide_images" /></label>

--- a/index.html
+++ b/index.html
@@ -73,12 +73,16 @@
       </form>
       <form id="options">
         <h3>Optional text around the edges</h3>
-        <label>Top Edge <input type="text" id="text1" /></label>
-        <label>Upper Right <input type="text" id="text2" /></label>
-        <label>Lower Right <input type="text" id="text3" /></label>
-        <label>Bottom Edge <input type="text" id="text4" /></label>
-        <label>Lower Left <input type="text" id="text5" /></label>
-        <label>Upper Left <input type="text" id="text6" /></label>
+        <label>Top Edge <input type="text" id="text1" data-idx="a" /></label>
+        <label>Upper Right <input type="text" id="text2" data-idx="b" /></label>
+        <label>Lower Right <input type="text" id="text3" data-idx="c" /></label>
+        <label>Bottom Edge <input type="text" id="text4" data-idx="d" /></label>
+        <label>Lower Left <input type="text" id="text5" data-idx="e" /></label>
+        <label>Upper Left <input type="text" id="text6" data-idx="f" /></label>
+        <hr>
+        <h3>Advanced Options</h3>
+        <label>Hide Images <input type="checkbox" id="hide_images" /></label>
+        <label>Hide Text <input type="checkbox" id="hide_text" /></label>
       </form>
     </section>
     <svg id="strip1" viewBox="-1 -1 1034 300"></svg>

--- a/js/hexa.js
+++ b/js/hexa.js
@@ -38,10 +38,10 @@ const p6 = { x: side * 0.5, y: ht * 2 };
 // key: t=text, s=strip, a=angle of rotation, x,y centerpoint
 // a2= angle of rotation for optional edge text
 const text_labels = [
-  { t: "1a", s: strip1, a: 120, a2: -120,  x: 3.5, y: 0.66 },
+  { t: "1a", s: strip1, a: 120, a2: -120, x: 3.5, y: 0.66 },
   { t: "1b", s: strip1, a: 120, a2: -60, x: 2, y: 0.33 },
   { t: "1c", s: strip1, a: 0, a2: -120, x: 0.5, y: 0.66 },
-  { t: "1d", s: strip2, a: 0, a2: -60,x: 3, y: 0.33 },
+  { t: "1d", s: strip2, a: 0, a2: -60, x: 3, y: 0.33 },
   { t: "1e", s: strip2, a: -120, a2: -120, x: 1.5, y: 0.66 },
   { t: "1f", s: strip1, a: -120, a2: -60, x: 5, y: 0.33 },
   { t: "2a", s: strip1, a: 180, a2: -60, x: 4, y: 0.33 },
@@ -228,27 +228,30 @@ function text(strip, txt, x, y, rotation, textRotation, neverHide) {
       txt
     )
   );
-  if (neverHide){
-      return;
+  if (neverHide) {
+    return;
   }
   strip.appendChild(
-    svg("g",
-        {
-           transform: `rotate(${textRotation}, ${x * side}, ${y * ht}) translate(0, ${ht / 3.4})`,
-           "class": "on_top",
-        }, [
-        svg(
-          "polygon",
-          {
-            fill: "#fff",
-            points: `${_x - side_2},${_y + _h} ${_x + side_2},${_y + _h} ${_x+(side_2-inset)},${_y-_h} ${_x-(side_2-inset)},${_y-_h}`
-          }
-        ),
+    svg(
+      "g",
+      {
+        transform: `rotate(${textRotation}, ${x * side}, ${
+          y * ht
+        }) translate(0, ${ht / 3.4})`,
+        class: "on_top",
+      },
+      [
+        svg("polygon", {
+          fill: "#fff",
+          points: `${_x - side_2},${_y + _h} ${_x + side_2},${_y + _h} ${
+            _x + (side_2 - inset)
+          },${_y - _h} ${_x - (side_2 - inset)},${_y - _h}`,
+        }),
         svg(
           "text",
           {
-           x: x * side,
-           y: y * ht,
+            x: x * side,
+            y: y * ht,
             fill: "#000",
             "text-anchor": "middle",
             "font-size": "0.5em",
@@ -256,8 +259,8 @@ function text(strip, txt, x, y, rotation, textRotation, neverHide) {
             id: `text_${txt}`,
           },
           ""
-        )
-       ]
+        ),
+      ]
     )
   );
 }
@@ -444,7 +447,7 @@ function chooseImage() {
   let idx = parseInt($("input[type=radio]:checked").value, 10); // target values are 1-based
   currImageIdx = idx;
   hex.viewBox.baseVal.x = 350 * (idx - 1);
-  //~ restoreOptionalText();
+  restoreOptionalText();
 }
 
 function downloadFile() {
@@ -481,19 +484,19 @@ function save(data) {
   reader.readAsDataURL(new Blob([data], { type: "image/svg+xml" }));
 }
 
-function updateText(evt){
-    let id = `#text_${currImageIdx}${evt.target.dataset.idx}`;
-    let value = evt.target.value.trim();
-    let target = document.querySelector(id);
-    target.textContent = value;
-    if (value){
-        target.parentElement.classList.add('has_text');
-    }else{
-        target.parentElement.classList.remove('has_text');
-    }
+function updateText(evt) {
+  let id = `#text_${currImageIdx}${evt.target.dataset.idx}`;
+  let value = evt.target.value.trim();
+  let target = document.querySelector(id);
+  target.textContent = value;
+  if (value) {
+    target.parentElement.classList.add("has_text");
+  } else {
+    target.parentElement.classList.remove("has_text");
+  }
+  updateOptionalText(evt);
 }
 
-// Not currently using this, remove if not needed
 function updateOptionalText(evt) {
   let currImageText = optionalText[currImageIdx - 1];
   for (let i = 0; i < 6; i++) {
@@ -501,7 +504,6 @@ function updateOptionalText(evt) {
   }
 }
 
-// Not currently using this, remove if not needed
 function restoreOptionalText() {
   let currImageText = optionalText[currImageIdx - 1];
   for (let i = 0; i < 6; i++) {
@@ -524,8 +526,12 @@ function subscribe_events() {
   listen("#filepicker", "change", loadFile);
   listen("#download-file", "click", downloadFile);
   listen("input[type=text]", "input", updateText);
-  listen("#hide_images", "change", evt => document.body.classList.toggle('hide_images', evt.target.checked));
-  listen("#hide_text", "change", evt => document.body.classList.toggle('hide_text', evt.target.checked));
+  listen("#hide_images", "change", evt =>
+    document.body.classList.toggle("hide_images", evt.target.checked)
+  );
+  listen("#hide_text", "change", evt =>
+    document.body.classList.toggle("hide_text", evt.target.checked)
+  );
 }
 
 function scrollToZoom(evt) {
@@ -598,7 +604,7 @@ function useHex(info) {
       href: `#hextri${imageIndex(info)}_${triangleIndex(info)}`,
       x: side * (stripX(info) - hexX(info)),
       y: ht * (stripY(info) - hexY(info)),
-      "class": "triangle_image",
+      class: "triangle_image",
       transform: rot(info),
     })
   );
@@ -607,7 +613,9 @@ function useHex(info) {
 function hex_to_strip() {
   text_labels.forEach(useHex);
   // put optional text back on top
-  document.querySelectorAll(".on_top").forEach(e => e.parentElement.appendChild(e));
+  document
+    .querySelectorAll(".on_top")
+    .forEach(e => e.parentElement.appendChild(e));
 }
 
 function gluingHints() {

--- a/js/hexa.js
+++ b/js/hexa.js
@@ -34,43 +34,44 @@ const p6 = { x: side * 0.5, y: ht * 2 };
 
 // text and rotations for strips
 // key: t=text, s=strip, a=angle of rotation, x,y centerpoint
+// a2= angle of rotation for optional edge text
 const text_labels = [
-  { t: "1a", s: strip1, a: 120, x: 3.5, y: 0.66 },
-  { t: "1b", s: strip1, a: 120, x: 2, y: 0.33 },
-  { t: "1c", s: strip1, a: 0, x: 0.5, y: 0.66 },
-  { t: "1d", s: strip2, a: 0, x: 3, y: 0.33 },
-  { t: "1e", s: strip2, a: -120, x: 1.5, y: 0.66 },
-  { t: "1f", s: strip1, a: -120, x: 5, y: 0.33 },
-  { t: "2a", s: strip1, a: 180, x: 4, y: 0.33 },
-  { t: "2b", s: strip1, a: 60, x: 2.5, y: 0.66 },
-  { t: "2c", s: strip1, a: 60, x: 1, y: 0.33 },
-  { t: "2d", s: strip2, a: -60, x: 3.5, y: 0.66 },
-  { t: "2e", s: strip2, a: -60, x: 2, y: 0.33 },
-  { t: "2f", s: strip2, a: 180, x: 0.5, y: 0.66 },
-  { t: "3a", s: strip1, a: 120, x: 4.5, y: 0.66 },
-  { t: "3b", s: strip1, a: 120, x: 3, y: 0.33 },
-  { t: "3c", s: strip1, a: 0, x: 1.5, y: 0.66 },
-  { t: "3d", s: strip2, a: 0, x: 4, y: 0.33 },
-  { t: "3e", s: strip2, a: -120, x: 2.5, y: 0.66 },
-  { t: "3f", s: strip2, a: -120, x: 1, y: 0.33 },
-  { t: "4a", s: strip1, a: 180, x: 1.5, y: 1.33 },
-  { t: "4b", s: strip1, a: 180, x: 1, y: 1.66 },
-  { t: "4c", s: strip2, a: 60, x: 2.5, y: 1.33 },
-  { t: "4d", s: strip2, a: 60, x: 2, y: 1.66 },
-  { t: "4e", s: strip1, a: -60, x: 4.5, y: 1.33 },
-  { t: "4f", s: strip1, a: -60, x: 4, y: 1.66 },
-  { t: "5a", s: strip1, a: 180, x: 2.5, y: 1.33 },
-  { t: "5b", s: strip1, a: 180, x: 2, y: 1.66 },
-  { t: "5c", s: strip2, a: 60, x: 3.5, y: 1.33 },
-  { t: "5d", s: strip2, a: 60, x: 3, y: 1.66 },
-  { t: "5e", s: strip1, a: -60, x: 5.5, y: 1.33 },
-  { t: "5f", s: strip1, a: -60, x: 5, y: 1.66 },
-  { t: "6a", s: strip1, a: 180, x: 3.5, y: 1.33 },
-  { t: "6b", s: strip1, a: 180, x: 3, y: 1.66 },
-  { t: "6c", s: strip2, a: 60, x: 4.5, y: 1.33 },
-  { t: "6d", s: strip2, a: 60, x: 4, y: 1.66 },
-  { t: "6e", s: strip2, a: -60, x: 1.5, y: 1.33 },
-  { t: "6f", s: strip2, a: -60, x: 1, y: 1.66 },
+  { t: "1a", s: strip1, a: 120, a2: -120,  x: 3.5, y: 0.66 },
+  { t: "1b", s: strip1, a: 120, a2: -60, x: 2, y: 0.33 },
+  { t: "1c", s: strip1, a: 0, a2: -120, x: 0.5, y: 0.66 },
+  { t: "1d", s: strip2, a: 0, a2: -60,x: 3, y: 0.33 },
+  { t: "1e", s: strip2, a: -120, a2: -120, x: 1.5, y: 0.66 },
+  { t: "1f", s: strip1, a: -120, a2: -60, x: 5, y: 0.33 },
+  { t: "2a", s: strip1, a: 180, a2: -60, x: 4, y: 0.33 },
+  { t: "2b", s: strip1, a: 60, a2: -120, x: 2.5, y: 0.66 },
+  { t: "2c", s: strip1, a: 60, a2: -60, x: 1, y: 0.33 },
+  { t: "2d", s: strip2, a: -60, a2: -120, x: 3.5, y: 0.66 },
+  { t: "2e", s: strip2, a: -60, a2: -60, x: 2, y: 0.33 },
+  { t: "2f", s: strip2, a: 180, a2: 120, x: 0.5, y: 0.66 },
+  { t: "3a", s: strip1, a: 120, a2: -120, x: 4.5, y: 0.66 },
+  { t: "3b", s: strip1, a: 120, a2: -60, x: 3, y: 0.33 },
+  { t: "3c", s: strip1, a: 0, a2: -120, x: 1.5, y: 0.66 },
+  { t: "3d", s: strip2, a: 0, a2: -60, x: 4, y: 0.33 },
+  { t: "3e", s: strip2, a: -120, a2: -120, x: 2.5, y: 0.66 },
+  { t: "3f", s: strip2, a: -120, a2: -60, x: 1, y: 0.33 },
+  { t: "4a", s: strip1, a: 180, a2: -60, x: 1.5, y: 1.33 },
+  { t: "4b", s: strip1, a: 180, a2: 0, x: 1, y: 1.66 },
+  { t: "4c", s: strip2, a: 60, a2: -60, x: 2.5, y: 1.33 },
+  { t: "4d", s: strip2, a: 60, a2: 0, x: 2, y: 1.66 },
+  { t: "4e", s: strip1, a: -60, a2: -60, x: 4.5, y: 1.33 },
+  { t: "4f", s: strip1, a: -60, a2: 0, x: 4, y: 1.66 },
+  { t: "5a", s: strip1, a: 180, a2: -60, x: 2.5, y: 1.33 },
+  { t: "5b", s: strip1, a: 180, a2: 0, x: 2, y: 1.66 },
+  { t: "5c", s: strip2, a: 60, a2: -60, x: 3.5, y: 1.33 },
+  { t: "5d", s: strip2, a: 60, a2: 0, x: 3, y: 1.66 },
+  { t: "5e", s: strip1, a: -60, a2: -60, x: 5.5, y: 1.33 },
+  { t: "5f", s: strip1, a: -60, a2: 0, x: 5, y: 1.66 },
+  { t: "6a", s: strip1, a: 180, a2: -60, x: 3.5, y: 1.33 },
+  { t: "6b", s: strip1, a: 180, a2: 0, x: 3, y: 1.66 },
+  { t: "6c", s: strip2, a: 60, a2: -60, x: 4.5, y: 1.33 },
+  { t: "6d", s: strip2, a: 60, a2: 0, x: 4, y: 1.66 },
+  { t: "6e", s: strip2, a: -60, a2: -60, x: 1.5, y: 1.33 },
+  { t: "6f", s: strip2, a: -60, a2: 0, x: 1, y: 1.66 },
 ];
 
 function defaultImage(idx) {
@@ -201,9 +202,9 @@ function path(strip, moves, clr) {
 //   );
 // }
 
-const textObj = o => text(o.s, o.t, o.x, o.y, o.a);
+const textObj = o => text(o.s, o.t, o.x, o.y, o.a, o.a2);
 
-function text(strip, txt, x, y, rotation) {
+function text(strip, txt, x, y, rotation, textRotation, neverHide) {
   strip.appendChild(
     svg(
       "text",
@@ -215,9 +216,29 @@ function text(strip, txt, x, y, rotation) {
         "dominant-baseline": "middle",
         "font-size": "2em",
         "font-family": "sans-serif",
+        class: neverHide ? "never_hide" : "",
         transform: `rotate(${rotation}, ${x * side}, ${y * ht})`,
       },
       txt
+    )
+  );
+  if (neverHide){
+      return;
+  }
+  strip.appendChild(
+    svg(
+        "text",
+        {
+            x: x * side,
+            y: y * ht,
+            fill: "#000",
+            "text-anchor": "middle",
+            "font-size": "0.5em",
+            "class": "on_top",
+            id: `text_${txt}`,
+            transform: `rotate(${textRotation}, ${x * side}, ${y * ht}) translate(0, ${ht / 3.5})`,
+        },
+        `placeholder ${txt}`
     )
   );
 }
@@ -404,7 +425,7 @@ function chooseImage() {
   let idx = parseInt($("input[type=radio]:checked").value, 10); // target values are 1-based
   currImageIdx = idx;
   hex.viewBox.baseVal.x = 350 * (idx - 1);
-  restoreOptionalText();
+  //~ restoreOptionalText();
 }
 
 function downloadFile() {
@@ -441,6 +462,12 @@ function save(data) {
   reader.readAsDataURL(new Blob([data], { type: "image/svg+xml" }));
 }
 
+function updateText(evt){
+    let id = `#text_${currImageIdx}${evt.target.dataset.idx}`;
+    document.querySelector(id).textContent = evt.target.value;
+}
+
+// Not currently using this, remove if not needed
 function updateOptionalText(evt) {
   let currImageText = optionalText[currImageIdx - 1];
   for (let i = 0; i < 6; i++) {
@@ -448,6 +475,7 @@ function updateOptionalText(evt) {
   }
 }
 
+// Not currently using this, remove if not needed
 function restoreOptionalText() {
   let currImageText = optionalText[currImageIdx - 1];
   for (let i = 0; i < 6; i++) {
@@ -469,7 +497,9 @@ function subscribe_events() {
   listen("#take-photo", "click", takePhoto);
   listen("#filepicker", "change", loadFile);
   listen("#download-file", "click", downloadFile);
-  listen("input[type=text]", "input", updateOptionalText);
+  listen("input[type=text]", "input", updateText);
+  listen("#hide_images", "change", evt => document.body.classList.toggle('hide_images', evt.target.checked));
+  listen("#hide_text", "change", evt => document.body.classList.toggle('hide_text', evt.target.checked));
 }
 
 function scrollToZoom(evt) {
@@ -542,6 +572,7 @@ function useHex(info) {
       href: `#hextri${imageIndex(info)}_${triangleIndex(info)}`,
       x: side * (stripX(info) - hexX(info)),
       y: ht * (stripY(info) - hexY(info)),
+      "class": "triangle_image",
       transform: rot(info),
     })
   );
@@ -549,14 +580,17 @@ function useHex(info) {
 
 function hex_to_strip() {
   text_labels.forEach(useHex);
+  // put optional text back on top
+  document.querySelectorAll(".on_top").forEach(e => e.parentElement.appendChild(e));
 }
 
 function gluingHints() {
   // Show which triangles get glued together at the end
-  textObj({ t: "B", s: strip1, a: 0, x: 0.5, y: 1.33 });
-  textObj({ t: "A", s: strip1, a: 0, x: 5.5, y: 0.66 });
-  textObj({ t: "a", s: strip2, a: 0, x: 0.5, y: 1.33 });
-  textObj({ t: "b", s: strip2, a: 0, x: 4.5, y: 0.66 });
+  // last param says not to hide these even when text is hidden
+  text(strip1, "A", 5.5, 0.66, 0, 0, true);
+  text(strip1, "B", 0.5, 1.33, 0, 0, true);
+  text(strip2, "a", 0.5, 1.33, 0, 0, true);
+  text(strip2, "b", 4.5, 0.66, 0, 0, true);
 }
 
 addText();

--- a/js/hexa.js
+++ b/js/hexa.js
@@ -2,6 +2,8 @@ import { html, svg, $, $$, listen, setAttributes } from "./dom.js";
 
 const side = 172; // 10 triangles across 1250 pixels
 const ht = 149; // height of triangle, 108.2531...
+const side_2 = Math.round(side / 2);
+const ht_2 = Math.round(ht / 2);
 
 const strip1 = $("#strip1");
 const strip2 = $("#strip2");
@@ -205,19 +207,23 @@ function path(strip, moves, clr) {
 const textObj = o => text(o.s, o.t, o.x, o.y, o.a, o.a2);
 
 function text(strip, txt, x, y, rotation, textRotation, neverHide) {
+  let _x = x * side;
+  let _y = y * ht;
+  let inset = 8;
+  let _h = 6;
   strip.appendChild(
     svg(
       "text",
       {
-        x: x * side,
-        y: y * ht,
+        x: _x,
+        y: _y,
         fill: "#CCC",
         "text-anchor": "middle",
         "dominant-baseline": "middle",
         "font-size": "2em",
         "font-family": "sans-serif",
         class: neverHide ? "never_hide" : "",
-        transform: `rotate(${rotation}, ${x * side}, ${y * ht})`,
+        transform: `rotate(${rotation}, ${_x}, ${_y})`,
       },
       txt
     )
@@ -226,19 +232,32 @@ function text(strip, txt, x, y, rotation, textRotation, neverHide) {
       return;
   }
   strip.appendChild(
-    svg(
-        "text",
+    svg("g",
         {
-            x: x * side,
-            y: y * ht,
+           transform: `rotate(${textRotation}, ${x * side}, ${y * ht}) translate(0, ${ht / 3.4})`,
+           "class": "on_top",
+        }, [
+        svg(
+          "polygon",
+          {
+            fill: "#fff",
+            points: `${_x - side_2},${_y + _h} ${_x + side_2},${_y + _h} ${_x+(side_2-inset)},${_y-_h} ${_x-(side_2-inset)},${_y-_h}`
+          }
+        ),
+        svg(
+          "text",
+          {
+           x: x * side,
+           y: y * ht,
             fill: "#000",
             "text-anchor": "middle",
             "font-size": "0.5em",
-            "class": "on_top",
+            "dominant-baseline": "middle",
             id: `text_${txt}`,
-            transform: `rotate(${textRotation}, ${x * side}, ${y * ht}) translate(0, ${ht / 3.5})`,
-        },
-        `placeholder ${txt}`
+          },
+          ""
+        )
+       ]
     )
   );
 }
@@ -464,7 +483,14 @@ function save(data) {
 
 function updateText(evt){
     let id = `#text_${currImageIdx}${evt.target.dataset.idx}`;
-    document.querySelector(id).textContent = evt.target.value;
+    let value = evt.target.value.trim();
+    let target = document.querySelector(id);
+    target.textContent = value;
+    if (value){
+        target.parentElement.classList.add('has_text');
+    }else{
+        target.parentElement.classList.remove('has_text');
+    }
 }
 
 // Not currently using this, remove if not needed

--- a/js/hexa.js
+++ b/js/hexa.js
@@ -17,6 +17,7 @@ const video = $("#video");
 const canvas = $("#canvas");
 const ctx = canvas.getContext("2d");
 let cameraInitialized = false;
+let optionalText = [[], [], [], [], [], []];
 
 const n4 = [1, 2, 3, 4];
 const n5 = [1, 2, 3, 4, 5];
@@ -403,6 +404,7 @@ function chooseImage() {
   let idx = parseInt($("input[type=radio]:checked").value, 10); // target values are 1-based
   currImageIdx = idx;
   hex.viewBox.baseVal.x = 350 * (idx - 1);
+  restoreOptionalText();
 }
 
 function downloadFile() {
@@ -439,6 +441,20 @@ function save(data) {
   reader.readAsDataURL(new Blob([data], { type: "image/svg+xml" }));
 }
 
+function updateOptionalText(evt) {
+  let currImageText = optionalText[currImageIdx - 1];
+  for (let i = 0; i < 6; i++) {
+    currImageText[i] = document.querySelector(`#text${i + 1}`).value;
+  }
+}
+
+function restoreOptionalText() {
+  let currImageText = optionalText[currImageIdx - 1];
+  for (let i = 0; i < 6; i++) {
+    document.querySelector(`#text${i + 1}`).value = currImageText[i] || "";
+  }
+}
+
 function subscribe_events() {
   listen("input[type=radio]", "input", chooseImage);
   $("#hex").addEventListener("wheel", scrollToZoom, { passive: false });
@@ -453,6 +469,7 @@ function subscribe_events() {
   listen("#take-photo", "click", takePhoto);
   listen("#filepicker", "change", loadFile);
   listen("#download-file", "click", downloadFile);
+  listen("input[type=text]", "input", updateOptionalText);
 }
 
 function scrollToZoom(evt) {

--- a/js/hexa.js
+++ b/js/hexa.js
@@ -284,6 +284,11 @@ function triangleIndex(info) {
   return info.t.charCodeAt(1) - 96;
 }
 
+function letterIndex(num) {
+  // convert number to letter. 1 = a, 2 = b, etc.
+  return String.fromCharCode(96 + num);
+}
+
 function imageIndex(info) {
   // convert number in name to number
   return parseInt(info.t[0], 10);
@@ -484,9 +489,7 @@ function save(data) {
   reader.readAsDataURL(new Blob([data], { type: "image/svg+xml" }));
 }
 
-function updateText(evt) {
-  let id = `#text_${currImageIdx}${evt.target.dataset.idx}`;
-  let value = evt.target.value.trim();
+function updateSVGText(id, value) {
   let target = document.querySelector(id);
   target.textContent = value;
   if (value) {
@@ -494,13 +497,19 @@ function updateText(evt) {
   } else {
     target.parentElement.classList.remove("has_text");
   }
+}
+
+function updateText(evt) {
+  let id = `#text_${currImageIdx}${evt.target.dataset.idx}`;
+  let value = evt.target.value.trim();
+  updateSVGText(id, value);
   updateOptionalText(evt);
 }
 
 function updateOptionalText(evt) {
   let currImageText = optionalText[currImageIdx - 1];
   for (let i = 0; i < 6; i++) {
-    currImageText[i] = document.querySelector(`#text${i + 1}`).value;
+    currImageText[i] = document.querySelector(`#text${i + 1}`).value.trim();
   }
 }
 
@@ -508,6 +517,18 @@ function restoreOptionalText() {
   let currImageText = optionalText[currImageIdx - 1];
   for (let i = 0; i < 6; i++) {
     document.querySelector(`#text${i + 1}`).value = currImageText[i] || "";
+  }
+}
+
+function repeatText() {
+  // copy the text from this face to all the faces
+  let currentImageText = optionalText[currImageIdx - 1];
+  for (let i = 0; i < 6; i++) {
+    for (let j = 0; j < 6; j++) {
+      optionalText[i][j] = currentImageText[j];
+      let id = `#text_${i + 1}${letterIndex(j + 1)}`;
+      updateSVGText(id, currentImageText[j]);
+    }
   }
 }
 
@@ -532,6 +553,7 @@ function subscribe_events() {
   listen("#hide_text", "change", evt =>
     document.body.classList.toggle("hide_text", evt.target.checked)
   );
+  listen("#copy_text", "click", repeatText);
 }
 
 function scrollToZoom(evt) {


### PR DESCRIPTION
Fixed #12 
Fixed #14 

* [x] Add CSS for hide text feature
* [x] Text hide text feature
* [x] Add CSS for hide images feature
* [x] Test hide images feature
* [x] Get text from inputs to optional fields around hexagon
* [x] Position optional fields properly
* [x] Add CSS for background colour only on text fields that are used
* [x] Add SVG shapes for background colour
* [x] Switch text input values when switching images/faces
* [x] Turn off autocomplete restoring values on page
* [x] Button to use this face's text across all faces
